### PR TITLE
fix: don't panic if there are no secrets

### DIFF
--- a/crates/bws/src/command/secret.rs
+++ b/crates/bws/src/command/secret.rs
@@ -2,7 +2,8 @@ use bitwarden::{
     secrets_manager::{
         secrets::{
             SecretCreateRequest, SecretGetRequest, SecretIdentifiersByProjectRequest,
-            SecretIdentifiersRequest, SecretPutRequest, SecretsDeleteRequest, SecretsGetRequest,
+            SecretIdentifiersRequest, SecretPutRequest, SecretResponse, SecretsDeleteRequest,
+            SecretsGetRequest,
         },
         ClientSecretsExt,
     },
@@ -105,6 +106,11 @@ pub(crate) async fn list(
             .list(&SecretIdentifiersRequest { organization_id })
             .await?
     };
+
+    if res.data.is_empty() {
+        serialize_response(Vec::<SecretResponse>::new(), output_settings);
+        return Ok(());
+    }
 
     let secret_ids = res.data.into_iter().map(|e| e.id).collect();
     let secrets = client


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1484

## 📔 Objective

We currently panic if we call `get_by_ids()` if there are no secrets. This change avoids the unnecessary get request and instead outputs `[]` when there are no secrets, bringing the behavior of `bws secret list` in line with `bws project list` when there are no projects.

## 🖼️ Screenshots

[![asciicast](https://asciinema.org/a/bEwxNjt9pVpW9JQsKqkfV9TON.svg)](https://asciinema.org/a/bEwxNjt9pVpW9JQsKqkfV9TON)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
