### PR TITLE
[BRE-848] Add Workflow Permissions

### DIFF
--- a/.github/workflows/build-cpp.yml
+++ b/.github/workflows/build-cpp.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   generate-schemas:
     name: Generate schemas

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   generate_schemas:
     name: Generate schemas

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -13,6 +13,9 @@ env:
   GO111MODULE: on
   GO_VERSION: "^1.21"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/build-java.yml
+++ b/.github/workflows/build-java.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   generate_schemas:
     name: Generate schemas

--- a/.github/workflows/build-napi.yml
+++ b/.github/workflows/build-napi.yml
@@ -14,6 +14,9 @@ defaults:
     shell: bash
     working-directory: crates/bitwarden-napi
 
+permissions:
+  contents: read
+
 jobs:
   generate_schemas:
     name: Generate schemas

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -14,6 +14,9 @@ defaults:
     shell: bash
     working-directory: languages/python
 
+permissions:
+  contents: read
+
 jobs:
   generate_schemas:
     name: Generate schemas

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -7,6 +7,9 @@ on:
       - "main"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Ruby

--- a/.github/workflows/build-rust-crates.yml
+++ b/.github/workflows/build-rust-crates.yml
@@ -10,6 +10,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Building ${{matrix.package}} for - ${{ matrix.os }}

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -10,6 +10,9 @@ on:
       - hotfix-rc
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build_rust:
     name: Build for ${{ matrix.settings.os }} ${{ matrix.settings.target }}

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -14,6 +14,10 @@ defaults:
     shell: bash
     working-directory: crates/bitwarden-wasm
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: Building @bitwarden/sdk-wasm

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -6,6 +6,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   cloc:
     name: CLOC

--- a/.github/workflows/direct-minimal-versions.yml
+++ b/.github/workflows/direct-minimal-versions.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   direct-minimal-versions:
     name: Check dependencies minimal versions for - ${{ matrix.settings.os }} - ${{ matrix.settings.target }}

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   enforce-label:
     name: EnforceLabel

--- a/.github/workflows/generate_schemas.yml
+++ b/.github/workflows/generate_schemas.yml
@@ -12,6 +12,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   schemas:
     name: Generate schemas

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   style:
     name: Check Style

--- a/.github/workflows/minimum-rust-version.yml
+++ b/.github/workflows/minimum-rust-version.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   msrv:
     name: Check MSRV for - ${{ matrix.settings.os }} - ${{ matrix.settings.target }}

--- a/.github/workflows/release-bws.yml
+++ b/.github/workflows/release-bws.yml
@@ -13,6 +13,10 @@ on:
           - Release
           - Dry Run
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/release-dotnet.yml
+++ b/.github/workflows/release-dotnet.yml
@@ -13,6 +13,10 @@ on:
           - Release
           - Dry Run
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -13,6 +13,10 @@ on:
           - Release
           - Dry Run
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -19,6 +19,10 @@ defaults:
     shell: bash
     working-directory: crates/bitwarden-napi
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -13,6 +13,10 @@ on:
           - Release
           - Dry Run
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -13,6 +13,10 @@ on:
           - Release
           - Dry Run
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -13,6 +13,10 @@ on:
           - Release
           - Dry Run
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -17,6 +17,10 @@ defaults:
   run:
     working-directory: languages/js/wasm
 
+permissions:
+  contents: write
+  actions: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -10,6 +10,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   ci-pass:
     name: CI is green


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-848](https://bitwarden.atlassian.net/browse/BRE-848)

## 📔 Objective

Adding permissions to all workflows not being updated by [BRE-831](https://bitwarden.atlassian.net/browse/BRE-831)
This will prepare for changing the org wide GitHub actions setting to `contents:read` and `packages:read` as the default permissions provided to workflows.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes