### PR TITLE
fix: build with better manylinux compatibility to prevent segfaults on different linux environments

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -52,22 +52,27 @@ jobs:
           - os: macos-13
             target: x86_64-apple-darwin
             python-version: "3.9"
+            build-args: ""
 
           - os: macos-13
             target: aarch64-apple-darwin
             python-version: "3.9"
+            build-args: ""
 
           - os: windows-2022
             target: x86_64-pc-windows-msvc
             python-version: "3.9"
+            build-args: ""
 
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             python-version: "3.9"
+            build-args: "--zig"
 
           - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             python-version: "3.9"
+            build-args: "--zig"
 
     steps:
       - name: Checkout repo
@@ -110,7 +115,7 @@ jobs:
         uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1.45.0
         with:
           target: ${{ matrix.settings.target }}
-          args: --release --interpreter python${{ matrix.settings.python-version }} --zig
+          args: --release --interpreter python${{ matrix.settings.python-version }} ${{ matrix.settings.build-args }}
           sccache: true
           working-directory: ${{ github.workspace }}/languages/python
 
@@ -119,7 +124,7 @@ jobs:
         uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1.45.0
         with:
           target: ${{ matrix.settings.target }}
-          args: --release --sdist --interpreter python${{ matrix.settings.python-version }} --zig
+          args: --release --sdist --interpreter python${{ matrix.settings.python-version }} ${{ matrix.settings.build-args }}
           working-directory: ${{ github.workspace }}/languages/python
 
       - name: Upload wheels

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -52,27 +52,27 @@ jobs:
           - os: macos-13
             target: x86_64-apple-darwin
             python-version: "3.9"
-            build-args: ""
+            maturin-build-args: ""
 
           - os: macos-13
             target: aarch64-apple-darwin
             python-version: "3.9"
-            build-args: ""
+            maturin-build-args: ""
 
           - os: windows-2022
             target: x86_64-pc-windows-msvc
             python-version: "3.9"
-            build-args: ""
+            maturin-build-args: ""
 
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             python-version: "3.9"
-            build-args: "--zig"
+            maturin-build-args: "--zig"
 
           - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             python-version: "3.9"
-            build-args: "--zig"
+            maturin-build-args: "--zig"
 
     steps:
       - name: Checkout repo
@@ -115,7 +115,7 @@ jobs:
         uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1.45.0
         with:
           target: ${{ matrix.settings.target }}
-          args: --release --interpreter python${{ matrix.settings.python-version }} ${{ matrix.settings.build-args }}
+          args: --release --interpreter python${{ matrix.settings.python-version }} ${{ matrix.settings.maturin-build-args }}
           sccache: true
           working-directory: ${{ github.workspace }}/languages/python
 
@@ -124,7 +124,7 @@ jobs:
         uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1.45.0
         with:
           target: ${{ matrix.settings.target }}
-          args: --release --sdist --interpreter python${{ matrix.settings.python-version }} ${{ matrix.settings.build-args }}
+          args: --release --sdist --interpreter python${{ matrix.settings.python-version }} ${{ matrix.settings.maturin-build-args }}
           working-directory: ${{ github.workspace }}/languages/python
 
       - name: Upload wheels

--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -81,13 +81,18 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921 # stable
         with:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: 0.15.1
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
@@ -105,9 +110,8 @@ jobs:
         uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1.45.0
         with:
           target: ${{ matrix.settings.target }}
-          args: --release --interpreter python${{ matrix.settings.python-version }}
+          args: --release --interpreter python${{ matrix.settings.python-version }} --zig
           sccache: true
-          manylinux: "2_28" # https://github.com/pola-rs/polars/pull/12211
           working-directory: ${{ github.workspace }}/languages/python
 
       - name: Build wheels (Linux - x86_64)
@@ -115,8 +119,7 @@ jobs:
         uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1.45.0
         with:
           target: ${{ matrix.settings.target }}
-          args: --release --sdist --interpreter python${{ matrix.settings.python-version }}
-          manylinux: "2_28" # https://github.com/pola-rs/polars/pull/12211
+          args: --release --sdist --interpreter python${{ matrix.settings.python-version }} --zig
           working-directory: ${{ github.workspace }}/languages/python
 
       - name: Upload wheels

--- a/languages/python/pyproject.toml
+++ b/languages/python/pyproject.toml
@@ -33,7 +33,6 @@ dev-linux = [
 
 [tool.maturin]
 bindings = "pyo3"
-compatibility = "2_28"
 include = [
   { path = "bitwarden_sdk/*.py", format = ["sdist", "wheel"] },
   { path = "LICENSE", format = ["sdist", "wheel"] }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1540

## 📔 Objective

Fixes the segfaults described in #1288 by building with `--zig` and lowering the `manylinux` compatibility settings from the explicitly defined `2_28` to `2_17`, [which is implied](https://www.maturin.rs/distribution.html?highlight=zig#build-wheels) when passing `--zig`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
