### PR TITLE
[BRE-1135] Adding dev release CD support for pushes to main

### DIFF
--- a/.github/workflows/build-python-wheels.yml
+++ b/.github/workflows/build-python-wheels.yml
@@ -8,11 +8,20 @@ on:
       - "rc"
       - "hotfix-rc"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      dev_version:
+        description: "Create a dev build (e.g., .dev1 suffix)"
+        required: true
+        type: boolean
 
 defaults:
   run:
     shell: bash
     working-directory: languages/python
+
+env:
+  _VERSION_FILE: ../../crates/bitwarden-py/Cargo.toml
 
 permissions:
   contents: read
@@ -33,8 +42,45 @@ jobs:
 
       - name: Get Package Version
         id: retrieve-version
+        env:
+          USE_DEV_VERSION: ${{ inputs.dev_version }}
         run: |
-          VERSION="$(grep -o '^version = ".*"' ../../crates/bitwarden-py/Cargo.toml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")"
+          VERSION="$(grep -o '^version = ".*"' "$_VERSION_FILE" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")"
+
+          if [ -z "$VERSION" ]; then
+            echo "==================================="
+            echo "[!] Could not determine package version from $_VERSION_FILE"
+            echo "==================================="
+            exit 1
+          fi
+
+          if [ "$USE_DEV_VERSION" = "true" ]; then
+            latest_dev_num=0
+
+            #pypi_url="https://pypi.org/pypi/bitwarden-sdk/json"
+            pypi_url="https://test.pypi.org/pypi/bitwarden-sdk/json" # For publishing dev packages to Test PyPi
+
+            # Get all versions from PyPI that match the current package version with dev suffix
+            dev_versions=$(curl -s "$pypi_url" | \
+                jq -r --arg version "$_PACKAGE_VERSION" \
+                '.releases | keys[] | select(test("^" + $version + "\\.dev[0-9]+$"))' || true)
+
+            if [ -n "$dev_versions" ]; then
+                # Extract dev numbers and find the latest
+                latest_dev_num=$(echo "$dev_versions" | \
+                    sed -n "s/^${_PACKAGE_VERSION}\.dev\([0-9]\+\)$/\1/p" | \
+                    sort -n | \
+                    tail -1)
+            fi
+
+            # Increment dev number
+            new_dev_num=$((latest_dev_num + 1))
+            dev_version_suffix=".dev${new_dev_num}"
+
+            VERSION="${VERSION}${dev_version_suffix}"
+          fi
+
+          echo "Package version: $VERSION"
           echo "package_version=$VERSION" >> $GITHUB_OUTPUT
 
   build:
@@ -78,6 +124,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Add dev version suffix
+        if: ${{ inputs.dev_version }}
+        run: |
+          echo "Updating version files with: $_PACKAGE_VERSION"
+
+          sed -i"" "s/^version = "[0-9]\.[0-9]\.[0-9]"/version = \"$_PACKAGE_VERSION\"/" "$_VERSION_FILE"
+          sed -i 's/__version__ = "[0-9]\.[0-9]\.[0-9]"/__version__ = "$_PACKAGE_VERSION"/' bitwarden_sdk/__init__.py
+
       - name: Setup Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
@@ -117,7 +171,6 @@ jobs:
           target: ${{ matrix.settings.target }}
           args: --release --interpreter python${{ matrix.settings.python-version }} ${{ matrix.settings.maturin-build-args }}
           sccache: true
-          working-directory: ${{ github.workspace }}/languages/python
 
       - name: Build wheels (Linux - x86_64)
         if: ${{ matrix.settings.target == 'x86_64-unknown-linux-gnu' }}
@@ -125,7 +178,6 @@ jobs:
         with:
           target: ${{ matrix.settings.target }}
           args: --release --sdist --interpreter python${{ matrix.settings.python-version }} ${{ matrix.settings.maturin-build-args }}
-          working-directory: ${{ github.workspace }}/languages/python
 
       - name: Upload wheels
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -21,6 +21,13 @@ defaults:
   run:
     shell: bash
 
+env:
+  _TARGET_DIR: target/wheels/dist
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   setup:
     name: Setup
@@ -68,74 +75,25 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: ${{ needs.setup.outputs.tag_name }}
-
-      - name: Install Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        with:
-          python-version: "3.9"
-
-      - name: Install twine
-        run: pip install twine
-
       - name: Get release assets
-        working-directory: ${{ github.workspace }}/target/wheels/dist
-        run: |
-          ARTIFACT_URLS=$(curl -sSL https://api.github.com/repos/bitwarden/sdk-sm/releases/tags/${{ needs.setup.outputs.tag_name }} | jq -r '.assets[].browser_download_url')
-          for url in $ARTIFACT_URLS; do
-            wget $url
-          done
-
-      - name: Unpack release assets
-        working-directory: ${{ github.workspace }}/target/wheels/dist
-        run: |
-          for file in *.zip; do
-            unzip $file
-          done
-
-      - name: Move files
-        working-directory: ${{ github.workspace }}/target/wheels/dist
-        run: |
-          find . -maxdepth 2 -type f -print0 | xargs -0 mv -t .
-          rm -rf */
-
-      - name: Log in to Azure
-        uses: bitwarden/gh-actions/azure-login@main
-        with:
-          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          client_id: ${{ secrets.AZURE_CLIENT_ID }}
-
-      - name: Retrieve pypi api token
-        id: retrieve-secret
-        uses: bitwarden/gh-actions/get-keyvault-secrets@main
-        with:
-          keyvault: "bitwarden-ci"
-          secrets: "pypi-api-token,
-            pypi-test-api-token"
-
-      - name: Log out from Azure
-        uses: bitwarden/gh-actions/azure-logout@main
-
-      - name: Check
-        working-directory: ${{ github.workspace }}/target/wheels
-        run: twine check dist/*
-
-      - name: Publish
-        if: ${{ inputs.release_type != 'Dry Run' }}
-        working-directory: ${{ github.workspace }}/target/wheels
+        working-directory: ${{ env._TARGET_DIR }}
         env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ steps.retrieve-secret.outputs.pypi-api-token }}
-        run: twine upload --repository pypi dist/*
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.setup.outputs.tag_name }}
+        run: |
+          gh release download $TAG_NAME --repo bitwarden/sdk-sm --pattern "bitwarden_sdk-*.whl"
 
-      - name: Dry Run - Publish
+      - name: Dry Run - Publish package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         if: ${{ inputs.release_type == 'Dry Run' }}
-        working-directory: ${{ github.workspace }}/target/wheels
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ steps.retrieve-secret.outputs.pypi-test-api-token }}
-        run: twine upload --repository testpypi dist/*
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: ${{ env._TARGET_DIR }}
+          verify-metadata: true # Runs twine check before upload
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        if: ${{ inputs.release_type != 'Dry Run' }}
+        with:
+          packages-dir: ${{ env._TARGET_DIR }}
+          verify-metadata: true # Runs twine check before upload

--- a/crates/bitwarden-py/Cargo.toml
+++ b/crates/bitwarden-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitwarden-py"
-version = "0.1.0"
+version = "1.0.0"
 publish = false
 
 authors.workspace = true

--- a/languages/python/pyproject.toml
+++ b/languages/python/pyproject.toml
@@ -17,7 +17,7 @@ description = "A Bitwarden Client for python"
 name = "bitwarden_sdk"
 readme = "README.md"
 requires-python = ">=3.0"
-version = "1.0.0"
+dynamic = ["version"] # Pull from crates/bitwarden-py/Cargo.toml
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1135](https://bitwarden.atlassian.net/browse/BRE-1135)
## 📔 Objective

Refactoring publish python to use OIDC<br/>Using dynamic version from Cargo.toml<br/>Updating Python version to 1.0.0 to match latest release<br/>Updating Python build to support dev builds<br/>
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes