### PR TITLE
Fix UTF-8 string corruption in C# FFI sync marshalling

### DIFF
--- a/crates/bitwarden-c/src/c.rs
+++ b/crates/bitwarden-c/src/c.rs
@@ -103,6 +103,13 @@ pub extern "C" fn free_mem(client_ptr: *mut CClient) {
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn free_string(str_ptr: *mut c_char) {
+    unsafe {
+        let _ = CString::from_raw(str_ptr);
+    }
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn abort_and_free_handle(join_handle_ptr: *mut tokio::task::JoinHandle<()>) {
     let join_handle = unsafe { Box::from_raw(join_handle_ptr) };
     join_handle.abort();

--- a/languages/csharp/Bitwarden.Sdk/BitwardenLibrary.cs
+++ b/languages/csharp/Bitwarden.Sdk/BitwardenLibrary.cs
@@ -11,7 +11,10 @@ internal static partial class BitwardenLibrary
     private static partial void free_mem(IntPtr handle);
 
     [LibraryImport("bitwarden_c", StringMarshalling = StringMarshalling.Utf8)]
-    private static partial string run_command(string json, BitwardenSafeHandle handle);
+    private static partial IntPtr run_command(string json, BitwardenSafeHandle handle);
+
+    [LibraryImport("bitwarden_c")]
+    private static partial void free_string(IntPtr str);
 
     internal delegate void OnCompleteCallback(IntPtr json);
 
@@ -31,7 +34,13 @@ internal static partial class BitwardenLibrary
 
     internal static void FreeMemory(IntPtr handle) => free_mem(handle);
 
-    internal static string RunCommand(string json, BitwardenSafeHandle handle) => run_command(json, handle);
+    internal static string RunCommand(string json, BitwardenSafeHandle handle)
+    {
+        var resultPtr = run_command(json, handle);
+        var result = Marshal.PtrToStringUTF8(resultPtr);
+        free_string(resultPtr);
+        return result;
+    }
 
     internal static Task<string> RunCommandAsync(string json, BitwardenSafeHandle handle, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1815

Fixes
https://github.com/bitwarden/sdk-sm/issues/1416

## 📔 Objective

Fix UTF-8 encoding bug where multi-byte characters (e.g., £ → Â£) are corrupted when retrieved through the C# SDK sync path
