### PR TITLE
fix: accept blank configs as valid

### DIFF
--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -8,7 +8,10 @@ use color_eyre::eyre::{Result, bail};
 use directories::BaseDirs;
 use serde::{Deserialize, Serialize};
 
-use crate::cli::{DEFAULT_CONFIG_DIRECTORY, DEFAULT_CONFIG_FILENAME, ProfileKey};
+use crate::{
+    cli::{DEFAULT_CONFIG_DIRECTORY, DEFAULT_CONFIG_FILENAME, ProfileKey},
+    state::DEFAULT_STATE_DIRECTORY,
+};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct Config {
@@ -29,11 +32,12 @@ pub(crate) struct Profile {
 
 impl Default for Profile {
     fn default() -> Self {
+        let state_dir = BaseDirs::new().map(|d| d.home_dir().join(DEFAULT_STATE_DIRECTORY));
         Self {
             server_base: Some("https://bitwarden.com".to_owned()),
             server_api: Some("https://api.bitwarden.com".to_owned()),
             server_identity: Some("https://identity.bitwarden.com".to_owned()),
-            state_dir: None,
+            state_dir,
             state_opt_out: Some("false".to_owned()),
         }
     }
@@ -97,8 +101,9 @@ pub(crate) fn load_config(config_file: Option<&Path>, must_exist: bool) -> Resul
     // In Docker, auto-create a default config if the file doesn't exist or is empty,
     // since containers typically don't have a pre-existing config file.
     if PathBuf::from("/.dockerenv").exists()
-        && file.exists()
-        && read_to_string(&file)?.trim().is_empty()
+        || PathBuf::from("/run/.containerenv").exists()
+            && file.exists()
+            && read_to_string(&file)?.trim().is_empty()
     {
         std::fs::write(&file, toml::to_string_pretty(&Config::default())?)?;
     }
@@ -107,7 +112,9 @@ pub(crate) fn load_config(config_file: Option<&Path>, must_exist: bool) -> Resul
         // In Docker, create a default config file on disk so callers that
         // read and write the config (e.g. `config server-base`) have a persisted file.
         // Skip this when must_exist is true so the contract is preserved.
-        if PathBuf::from("/.dockerenv").exists() && !must_exist {
+        if PathBuf::from("/.dockerenv").exists()
+            || PathBuf::from("/run/.containerenv").exists() && !must_exist
+        {
             if let Some(parent) = file.parent() {
                 std::fs::create_dir_all(parent)?;
             }

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -97,17 +97,22 @@ pub(crate) fn load_config(config_file: Option<&Path>, must_exist: bool) -> Resul
     // In Docker, auto-create a default config if the file doesn't exist or is empty,
     // since containers typically don't have a pre-existing config file.
     if PathBuf::from("/.dockerenv").exists()
-        && (!file.exists() || read_to_string(&file)?.trim().is_empty())
+        && file.exists()
+        && read_to_string(&file)?.trim().is_empty()
     {
-        let default = toml::to_string_pretty(&Config::default())?;
-        if let Some(parent) = file.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(&file, default)?;
-        return Ok(Config::default());
+        std::fs::write(&file, toml::to_string_pretty(&Config::default())?)?;
     }
 
     if !file.exists() {
+        // In Docker, create a default config file on disk so callers that
+        // read and write the config (e.g. `config server-base`) have a persisted file.
+        // Skip this when must_exist is true so the contract is preserved.
+        if PathBuf::from("/.dockerenv").exists() && !must_exist {
+            if let Some(parent) = file.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&file, toml::to_string_pretty(&Config::default())?)?;
+        }
         if must_exist {
             bail!("Config file doesn't exist");
         }

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -119,6 +119,13 @@ pub(crate) fn load_config(config_file: Option<&Path>, must_exist: bool) -> Resul
         return Ok(Config::default());
     }
 
+    if file.is_dir() {
+        bail!(
+            "Config file path is a directory. When mounting a config file into a container, ensure \
+             the host file exists first (e.g. `touch`) so your container engine mounts it as a file."
+        );
+    }
+
     let content = read_to_string(&file)?;
     let config: Config = toml::from_str(&content)?;
     Ok(config)

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -15,7 +15,7 @@ pub(crate) struct Config {
     pub profiles: HashMap<String, Profile>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct Profile {
     #[serde(deserialize_with = "deserialize_trimmed_url", default)]
     pub server_base: Option<String>,
@@ -23,8 +23,20 @@ pub(crate) struct Profile {
     pub server_api: Option<String>,
     #[serde(deserialize_with = "deserialize_trimmed_url", default)]
     pub server_identity: Option<String>,
-    pub state_dir: Option<String>,
+    pub state_dir: Option<PathBuf>,
     pub state_opt_out: Option<String>,
+}
+
+impl Default for Profile {
+    fn default() -> Self {
+        Self {
+            server_base: Some("https://bitwarden.com".to_owned()),
+            server_api: Some("https://api.bitwarden.com".to_owned()),
+            server_identity: Some("https://identity.bitwarden.com".to_owned()),
+            state_dir: None,
+            state_opt_out: Some("false".to_owned()),
+        }
+    }
 }
 
 fn deserialize_trimmed_url<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
@@ -50,7 +62,7 @@ impl ProfileKey {
             ProfileKey::server_base => p.server_base = Some(value),
             ProfileKey::server_api => p.server_api = Some(value),
             ProfileKey::server_identity => p.server_identity = Some(value),
-            ProfileKey::state_dir => p.state_dir = Some(value),
+            ProfileKey::state_dir => p.state_dir = Some(value.into()),
             ProfileKey::state_opt_out => p.state_opt_out = Some(value),
         }
     }
@@ -82,13 +94,28 @@ fn get_config_path(config_file: Option<&Path>, ensure_folder_exists: bool) -> Re
 pub(crate) fn load_config(config_file: Option<&Path>, must_exist: bool) -> Result<Config> {
     let file = get_config_path(config_file, false)?;
 
-    let content = match file.exists() {
-        true => read_to_string(file),
-        false if must_exist => bail!("Config file doesn't exist"),
-        false => return Ok(Config::default()),
-    };
+    // In Docker, auto-create a default config if the file doesn't exist or is empty,
+    // since containers typically don't have a pre-existing config file.
+    if PathBuf::from("/.dockerenv").exists()
+        && (!file.exists() || read_to_string(&file)?.trim().is_empty())
+    {
+        let default = toml::to_string_pretty(&Config::default())?;
+        if let Some(parent) = file.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&file, default)?;
+        return Ok(Config::default());
+    }
 
-    let config: Config = toml::from_str(&content?)?;
+    if !file.exists() {
+        if must_exist {
+            bail!("Config file doesn't exist");
+        }
+        return Ok(Config::default());
+    }
+
+    let content = read_to_string(&file)?;
+    let config: Config = toml::from_str(&content)?;
     Ok(config)
 }
 

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -28,6 +28,7 @@ pub(crate) struct Profile {
     #[serde(deserialize_with = "deserialize_trimmed_url", default)]
     pub server_identity: Option<String>,
     pub state_dir: Option<PathBuf>,
+    #[serde(deserialize_with = "deserialize_as_string", default)]
     pub state_opt_out: Option<String>,
 }
 
@@ -54,6 +55,14 @@ where
 {
     let opt_string: Option<String> = Option::deserialize(deserializer)?;
     Ok(opt_string.map(|s| s.trim_end_matches('/').to_string()))
+}
+
+fn deserialize_as_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let val: Option<toml::Value> = Option::deserialize(deserializer)?;
+    Ok(val.map(|v| v.to_string()))
 }
 
 impl ProfileKey {

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -32,7 +32,11 @@ pub(crate) struct Profile {
 
 impl Default for Profile {
     fn default() -> Self {
-        let state_dir = BaseDirs::new().map(|d| d.home_dir().join(DEFAULT_STATE_DIRECTORY));
+        let state_dir = BaseDirs::new().map(|d| {
+            d.home_dir()
+                .join(DEFAULT_CONFIG_DIRECTORY)
+                .join(DEFAULT_STATE_DIRECTORY)
+        });
         Self {
             server_base: Some("https://bitwarden.com".to_owned()),
             server_api: Some("https://api.bitwarden.com".to_owned()),
@@ -97,24 +101,21 @@ fn get_config_path(config_file: Option<&Path>, ensure_folder_exists: bool) -> Re
 
 pub(crate) fn load_config(config_file: Option<&Path>, must_exist: bool) -> Result<Config> {
     let file = get_config_path(config_file, false)?;
+    let in_container =
+        PathBuf::from("/.dockerenv").exists() || PathBuf::from("/run/.containerenv").exists();
 
-    // In Docker, auto-create a default config if the file doesn't exist or is empty,
-    // since containers typically don't have a pre-existing config file.
-    if PathBuf::from("/.dockerenv").exists()
-        || PathBuf::from("/run/.containerenv").exists()
-            && file.exists()
-            && read_to_string(&file)?.trim().is_empty()
-    {
+    // In a container, auto-populate an empty config file where an empty mounted file is a common
+    // scenario.
+    if in_container && file.exists() && read_to_string(&file)?.trim().is_empty() {
         std::fs::write(&file, toml::to_string_pretty(&Config::default())?)?;
     }
 
     if !file.exists() {
-        // In Docker, create a default config file on disk so callers that
-        // read and write the config (e.g. `config server-base`) have a persisted file.
-        // Skip this when must_exist is true so the contract is preserved.
-        if PathBuf::from("/.dockerenv").exists()
-            || PathBuf::from("/run/.containerenv").exists() && !must_exist
-        {
+        // In a container, create a default config file on disk so callers
+        // that read and write the config (e.g. `config server-base`) have a
+        // persisted file. Skip this when must_exist is true so the contract
+        // is preserved.
+        if in_container && !must_exist {
             if let Some(parent) = file.parent() {
                 std::fs::create_dir_all(parent)?;
             }

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -15,6 +15,7 @@ use crate::{
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct Config {
+    #[serde(default)]
     pub profiles: HashMap<String, Profile>,
 }
 
@@ -101,26 +102,8 @@ fn get_config_path(config_file: Option<&Path>, ensure_folder_exists: bool) -> Re
 
 pub(crate) fn load_config(config_file: Option<&Path>, must_exist: bool) -> Result<Config> {
     let file = get_config_path(config_file, false)?;
-    let in_container =
-        PathBuf::from("/.dockerenv").exists() || PathBuf::from("/run/.containerenv").exists();
-
-    // In a container, auto-populate an empty config file where an empty mounted file is a common
-    // scenario.
-    if in_container && file.exists() && read_to_string(&file)?.trim().is_empty() {
-        std::fs::write(&file, toml::to_string_pretty(&Config::default())?)?;
-    }
 
     if !file.exists() {
-        // In a container, create a default config file on disk so callers
-        // that read and write the config (e.g. `config server-base`) have a
-        // persisted file. Skip this when must_exist is true so the contract
-        // is preserved.
-        if in_container && !must_exist {
-            if let Some(parent) = file.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            std::fs::write(&file, toml::to_string_pretty(&Config::default())?)?;
-        }
         if must_exist {
             bail!("Config file doesn't exist");
         }

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -62,7 +62,10 @@ where
     D: serde::Deserializer<'de>,
 {
     let val: Option<toml::Value> = Option::deserialize(deserializer)?;
-    Ok(val.map(|v| v.to_string()))
+    Ok(val.map(|v| match v {
+        toml::Value::String(s) => s,
+        other => other.to_string(),
+    }))
 }
 
 impl ProfileKey {
@@ -250,6 +253,48 @@ mod tests {
 
         let c = load_config(None, false);
         assert!(c.is_ok());
+    }
+
+    #[test]
+    fn config_empty_file_is_valid() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        write!(tmpfile.as_file(), "\n").unwrap();
+
+        let c = load_config(Some(Path::new(tmpfile.as_ref())), true);
+        let config = c.unwrap();
+        assert_eq!(0, config.profiles.len());
+    }
+
+    #[test]
+    fn config_state_opt_out_as_boolean() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        write!(
+            tmpfile.as_file(),
+            "[profiles.default]\nstate_opt_out = true\n"
+        )
+        .unwrap();
+
+        let c = load_config(Some(Path::new(tmpfile.as_ref())), true);
+        assert_eq!(
+            Some("true".to_string()),
+            c.unwrap().profiles["default"].state_opt_out
+        );
+    }
+
+    #[test]
+    fn config_state_opt_out_as_string() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        write!(
+            tmpfile.as_file(),
+            "[profiles.default]\nstate_opt_out = \"false\"\n"
+        )
+        .unwrap();
+
+        let c = load_config(Some(Path::new(tmpfile.as_ref())), true);
+        assert_eq!(
+            Some("false".to_string()),
+            c.unwrap().profiles["default"].state_opt_out
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1184

## 📔 Objective

Make the container use-case easier. When you attempt to use a custom config file with a container, you usually want to mount one. However, when you mount a non-existent file on the host `-v ~/.config/bws/config-that-does-not-exist-yet:/config`, Docker and Podman will assume that `config-that-does-not-exist-yet` is a _directory_, not a file. This will result in cryptic errors about the config file.

So we need to `touch ~/.config/bws/config-that-does-not-exist-yet` to make it exist on the host first so it can be mounted as a file correctly. However, `bws` used to throw an error about an invalid config file because the config file was empty.

This change allows blank config files to make use-cases like this easier. 