### PR TITLE
fix: empty configs are valid

### DIFF
--- a/crates/bws/src/command/run.rs
+++ b/crates/bws/src/command/run.rs
@@ -80,14 +80,13 @@ pub(crate) async fn run(
         .await?
         .data;
 
-    if !uuids_as_keynames {
-        if let Some(duplicate) = secrets.iter().map(|s| &s.key).duplicates().next() {
+    if !uuids_as_keynames
+        && let Some(duplicate) = secrets.iter().map(|s| &s.key).duplicates().next() {
             bail!(
                 "Multiple secrets with name: '{}'. Use --uuids-as-keynames or use unique names for secrets",
                 duplicate
             );
         }
-    }
 
     let environment: HashMap<String, String> = secrets
         .into_iter()

--- a/crates/bws/src/command/run.rs
+++ b/crates/bws/src/command/run.rs
@@ -81,12 +81,13 @@ pub(crate) async fn run(
         .data;
 
     if !uuids_as_keynames
-        && let Some(duplicate) = secrets.iter().map(|s| &s.key).duplicates().next() {
-            bail!(
-                "Multiple secrets with name: '{}'. Use --uuids-as-keynames or use unique names for secrets",
-                duplicate
-            );
-        }
+        && let Some(duplicate) = secrets.iter().map(|s| &s.key).duplicates().next()
+    {
+        bail!(
+            "Multiple secrets with name: '{}'. Use --uuids-as-keynames or use unique names for secrets",
+            duplicate
+        );
+    }
 
     let environment: HashMap<String, String> = secrets
         .into_iter()

--- a/crates/bws/src/command/secret.rs
+++ b/crates/bws/src/command/secret.rs
@@ -174,7 +174,7 @@ pub(crate) async fn edit(
     let value_changed = secret
         .value
         .as_ref()
-        .map_or(false, |v| v != &old_secret.value);
+        .is_some_and(|v| v != &old_secret.value);
 
     let new_secret = client
         .secrets()

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -84,10 +84,9 @@ fn get_config_path(config_file: Option<&Path>, ensure_folder_exists: bool) -> Re
         }
     };
 
-    if ensure_folder_exists
-        && let Some(parent_folder) = config_file.parent() {
-            std::fs::create_dir_all(parent_folder)?;
-        }
+    if ensure_folder_exists && let Some(parent_folder) = config_file.parent() {
+        std::fs::create_dir_all(parent_folder)?;
+    }
 
     Ok(config_file)
 }

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -8,7 +8,10 @@ use color_eyre::eyre::{Result, bail};
 use directories::BaseDirs;
 use serde::{Deserialize, Serialize};
 
-use crate::cli::{DEFAULT_CONFIG_DIRECTORY, DEFAULT_CONFIG_FILENAME, ProfileKey};
+use crate::{
+    cli::{DEFAULT_CONFIG_DIRECTORY, DEFAULT_CONFIG_FILENAME, ProfileKey},
+    util::string_to_bool,
+};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct Config {
@@ -25,9 +28,8 @@ pub(crate) struct Profile {
     #[serde(deserialize_with = "deserialize_trimmed_url", default)]
     pub server_identity: Option<String>,
     pub state_dir: Option<String>,
-    #[serde(deserialize_with = "deserialize_as_string", default)]
-    // treat `state_opt_out = true` as valid
-    pub state_opt_out: Option<String>,
+    #[serde(deserialize_with = "allow_string", default)]
+    pub state_opt_out: Option<bool>,
 }
 
 fn deserialize_trimmed_url<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
@@ -38,15 +40,21 @@ where
     Ok(opt_string.map(|s| s.trim_end_matches('/').to_string()))
 }
 
-fn deserialize_as_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+fn allow_string<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let val: Option<toml::Value> = Option::deserialize(deserializer)?;
-    Ok(val.map(|v| match v {
-        toml::Value::String(s) => s,
-        other => other.to_string(),
-    }))
+    val.map(|v| -> Result<bool, D::Error> {
+        match v {
+            toml::Value::Boolean(s) => Ok(s),
+            toml::Value::String(s) => Ok(string_to_bool(&s).unwrap_or_default()),
+            _ => Err(<D::Error as serde::de::Error>::custom(
+                "only bools and strings are accepted",
+            )),
+        }
+    })
+    .transpose()
 }
 
 impl ProfileKey {
@@ -65,7 +73,9 @@ impl ProfileKey {
             ProfileKey::server_api => p.server_api = Some(value),
             ProfileKey::server_identity => p.server_identity = Some(value),
             ProfileKey::state_dir => p.state_dir = Some(value),
-            ProfileKey::state_opt_out => p.state_opt_out = Some(value),
+            ProfileKey::state_opt_out => {
+                p.state_opt_out = Some(string_to_bool(&value).unwrap_or_default())
+            }
         }
     }
 }
@@ -252,10 +262,7 @@ mod tests {
         .unwrap();
 
         let c = load_config(Some(Path::new(tmpfile.as_ref())), true);
-        assert_eq!(
-            Some("true".to_string()),
-            c.unwrap().profiles["default"].state_opt_out
-        );
+        assert_eq!(Some(true), c.unwrap().profiles["default"].state_opt_out);
     }
 
     #[test]
@@ -268,10 +275,7 @@ mod tests {
         .unwrap();
 
         let c = load_config(Some(Path::new(tmpfile.as_ref())), true);
-        assert_eq!(
-            Some("false".to_string()),
-            c.unwrap().profiles["default"].state_opt_out
-        );
+        assert_eq!(Some(false), c.unwrap().profiles["default"].state_opt_out);
     }
 
     #[test]

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -12,6 +12,7 @@ use crate::cli::{DEFAULT_CONFIG_DIRECTORY, DEFAULT_CONFIG_FILENAME, ProfileKey};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub(crate) struct Config {
+    #[serde(default)]
     pub profiles: HashMap<String, Profile>,
 }
 
@@ -24,6 +25,8 @@ pub(crate) struct Profile {
     #[serde(deserialize_with = "deserialize_trimmed_url", default)]
     pub server_identity: Option<String>,
     pub state_dir: Option<String>,
+    #[serde(deserialize_with = "deserialize_as_string", default)]
+    // treat `state_opt_out = true` as valid
     pub state_opt_out: Option<String>,
 }
 
@@ -33,6 +36,17 @@ where
 {
     let opt_string: Option<String> = Option::deserialize(deserializer)?;
     Ok(opt_string.map(|s| s.trim_end_matches('/').to_string()))
+}
+
+fn deserialize_as_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let val: Option<toml::Value> = Option::deserialize(deserializer)?;
+    Ok(val.map(|v| match v {
+        toml::Value::String(s) => s,
+        other => other.to_string(),
+    }))
 }
 
 impl ProfileKey {
@@ -50,7 +64,7 @@ impl ProfileKey {
             ProfileKey::server_base => p.server_base = Some(value),
             ProfileKey::server_api => p.server_api = Some(value),
             ProfileKey::server_identity => p.server_identity = Some(value),
-            ProfileKey::state_dir => p.state_dir = Some(value),
+            ProfileKey::state_dir => p.state_dir = Some(value.into()),
             ProfileKey::state_opt_out => p.state_opt_out = Some(value),
         }
     }
@@ -81,6 +95,13 @@ fn get_config_path(config_file: Option<&Path>, ensure_folder_exists: bool) -> Re
 
 pub(crate) fn load_config(config_file: Option<&Path>, must_exist: bool) -> Result<Config> {
     let file = get_config_path(config_file, false)?;
+
+    if file.is_dir() {
+        bail!(
+            "Config file path is a directory. Before mounting a config file into a container, ensure \
+             the host file exists first (e.g. `touch`) so your container engine mounts it as a file."
+        );
+    }
 
     let content = match file.exists() {
         true => read_to_string(file),
@@ -211,6 +232,48 @@ mod tests {
 
         let c = load_config(None, false);
         assert!(c.is_ok());
+    }
+
+    #[test]
+    fn config_empty_file_is_valid() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        write!(tmpfile.as_file(), "").unwrap();
+
+        let c = load_config(Some(Path::new(tmpfile.as_ref())), true);
+        let config = c.unwrap();
+        assert_eq!(0, config.profiles.len());
+    }
+
+    #[test]
+    fn config_state_opt_out_as_boolean() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        write!(
+            tmpfile.as_file(),
+            "[profiles.default]\nstate_opt_out = true\n"
+        )
+        .unwrap();
+
+        let c = load_config(Some(Path::new(tmpfile.as_ref())), true);
+        assert_eq!(
+            Some("true".to_string()),
+            c.unwrap().profiles["default"].state_opt_out
+        );
+    }
+
+    #[test]
+    fn config_state_opt_out_as_string() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        write!(
+            tmpfile.as_file(),
+            "[profiles.default]\nstate_opt_out = \"false\"\n"
+        )
+        .unwrap();
+
+        let c = load_config(Some(Path::new(tmpfile.as_ref())), true);
+        assert_eq!(
+            Some("false".to_string()),
+            c.unwrap().profiles["default"].state_opt_out
+        );
     }
 
     #[test]

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -64,7 +64,7 @@ impl ProfileKey {
             ProfileKey::server_base => p.server_base = Some(value),
             ProfileKey::server_api => p.server_api = Some(value),
             ProfileKey::server_identity => p.server_identity = Some(value),
-            ProfileKey::state_dir => p.state_dir = Some(value.into()),
+            ProfileKey::state_dir => p.state_dir = Some(value),
             ProfileKey::state_opt_out => p.state_opt_out = Some(value),
         }
     }
@@ -84,11 +84,10 @@ fn get_config_path(config_file: Option<&Path>, ensure_folder_exists: bool) -> Re
         }
     };
 
-    if ensure_folder_exists {
-        if let Some(parent_folder) = config_file.parent() {
+    if ensure_folder_exists
+        && let Some(parent_folder) = config_file.parent() {
             std::fs::create_dir_all(parent_folder)?;
         }
-    }
 
     Ok(config_file)
 }

--- a/crates/bws/src/config.rs
+++ b/crates/bws/src/config.rs
@@ -48,6 +48,7 @@ where
     val.map(|v| -> Result<bool, D::Error> {
         match v {
             toml::Value::Boolean(s) => Ok(s),
+            toml::Value::Integer(n) => Ok(n != 0),
             toml::Value::String(s) => Ok(string_to_bool(&s).unwrap_or_default()),
             _ => Err(<D::Error as serde::de::Error>::custom(
                 "only bools and strings are accepted",

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -189,7 +189,7 @@ fn get_state_opt_out(profile: &Option<Profile>) -> bool {
     if let Some(profile) = profile
         && let Some(state_opt_out) = &profile.state_opt_out
     {
-        return util::string_to_bool(state_opt_out).unwrap_or(false);
+        return *state_opt_out;
     }
 
     false

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -187,9 +187,10 @@ fn get_config_profile(
 
 fn get_state_opt_out(profile: &Option<Profile>) -> bool {
     if let Some(profile) = profile
-        && let Some(state_opt_out) = &profile.state_opt_out {
-            return util::string_to_bool(state_opt_out).unwrap_or(false);
-        }
+        && let Some(state_opt_out) = &profile.state_opt_out
+    {
+        return util::string_to_bool(state_opt_out).unwrap_or(false);
+    }
 
     false
 }

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -170,10 +170,10 @@ fn get_config_profile(
 
     let profile = if let Some(server_url) = server_url {
         let mut p = config::Profile::from_url(server_url)?;
-        if p.state_opt_out.is_none() {
-            if let Some(default) = config.select_profile("default", false)? {
-                p.state_opt_out = default.state_opt_out;
-            }
+        if p.state_opt_out.is_none()
+            && let Some(default) = config.select_profile("default", false)?
+        {
+            p.state_opt_out = default.state_opt_out;
         }
         Some(p)
     } else {

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -166,8 +166,16 @@ fn get_config_profile(
     config_file: &Option<PathBuf>,
     access_token: &str,
 ) -> Result<Option<config::Profile>, color_eyre::Report> {
+    let config = config::load_config(config_file.as_deref(), config_file.is_some())?;
+
     let profile = if let Some(server_url) = server_url {
-        Some(config::Profile::from_url(server_url)?)
+        let mut p = config::Profile::from_url(server_url)?;
+        if p.state_opt_out.is_none() {
+            if let Some(default) = config.select_profile("default", false)? {
+                p.state_opt_out = default.state_opt_out;
+            }
+        }
+        Some(p)
     } else {
         let profile_defined = profile.is_some();
 
@@ -179,7 +187,6 @@ fn get_config_profile(
                 .to_string()
         };
 
-        let config = config::load_config(config_file.as_deref(), config_file.is_some())?;
         config.select_profile(&profile_key, profile_defined)?
     };
     Ok(profile)

--- a/crates/bws/src/main.rs
+++ b/crates/bws/src/main.rs
@@ -113,7 +113,7 @@ async fn process_commands() -> Result<()> {
         .await?;
 
     let organization_id = match client.get_access_token_organization() {
-        Some(id) => id.into(),
+        Some(id) => id,
         None => {
             error!("Access token isn't associated to an organization.");
             return Ok(());
@@ -186,11 +186,10 @@ fn get_config_profile(
 }
 
 fn get_state_opt_out(profile: &Option<Profile>) -> bool {
-    if let Some(profile) = profile {
-        if let Some(state_opt_out) = &profile.state_opt_out {
+    if let Some(profile) = profile
+        && let Some(state_opt_out) = &profile.state_opt_out {
             return util::string_to_bool(state_opt_out).unwrap_or(false);
         }
-    }
 
     false
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1184

## 📔 Objective

Treat empty config files as valid and provide friendly error for container cases where the container engine creates a directory instead of a file for the config.