### PR TITLE
fix: aarch64 CLI builds

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -298,7 +298,7 @@ jobs:
           key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.os }}
 
       - name: Install Zigbuild
-        run: cargo install cargo-zigbuild --locked --git https://github.com/rust-cross/cargo-zigbuild --rev 6f7e1336c9cd13cf1b3704f93c40fcf84caaed6b # 0.18.4
+        run: cargo install cargo-zigbuild --locked --git https://github.com/rust-cross/cargo-zigbuild --rev 9ef2a444f09723f1b205017f241005819d4c0587 # 0.23.2
 
       - name: Build
         env:

--- a/.github/workflows/build-rust-cross-platform.yml
+++ b/.github/workflows/build-rust-cross-platform.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install Zigbuild
         if: ${{ contains(matrix.settings.target, 'musl') }}
-        run: cargo install cargo-zigbuild --locked --git https://github.com/rust-cross/cargo-zigbuild --rev 6f7e1336c9cd13cf1b3704f93c40fcf84caaed6b # 0.18.4
+        run: cargo install cargo-zigbuild --locked --git https://github.com/rust-cross/cargo-zigbuild --rev 9ef2a444f09723f1b205017f241005819d4c0587 # 0.23.2
 
       - name: Add build architecture
         run: rustup target add ${{ matrix.settings.target }}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-2077

## 📔 Objective

Newer builds of Rust added `-Wl,--fix-cortex-a53-843419` to the pre-link-args of all aarch64 Linux target specs (https://github.com/rust-lang/rust/pull/155453). This is a GNU `ld` flag that fixes a Cortex-A53 CPU erratum. Zig's linker (`lld`) doesn't support this flag, causing the build to fail.